### PR TITLE
Update README to showcase ember-cp-validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,29 @@ ember install ember-cp-validations
 Usage
 ------------------------------------------------------------------------------
 
-Define your model and its validations as described in [Ember CP Validations](https://github.com/offirgolan/ember-cp-validations).
+Define your model and its validations as described in [Ember CP Validations](https://github.com/offirgolan/ember-cp-validations):
+
+```js
+import Ember from 'ember';
+import { validator, buildValidations } from 'ember-cp-validations';
+
+const Validations = buildValidations({
+  username: validator('presence', true),
+  email: validator('format', { type: 'email' }),
+  password: validator('length', { min: 10 }),
+});
+
+export default Ember.Component.extend(Validations, {
+  username: null,
+  email: null,
+  password: null,
+});
+```
+
 Then assign the model to your form:
 
 ```hbs
-<BsForm @model={{changeset this.user this.userValidations}} as |form|>
+<BsForm @model={{this}} as |form|>
   <form.element @label="Username" @controlType="text" @property="username" />
   <form.element @label="Email" @controlType="email" @property="email" />
   <form.element @label="Password" @controlType="password" @property="password" />


### PR DESCRIPTION
Before the template was using `{{changeset}}` helper provided by ember-changeset-validations. I guess this was a copy and paste error.

Haven't used Ember CP Validations for a long time. To be honest I'm a little bit shocked how much its documentation is behind recent Ember versions. I'm not sure if that usage example, which is mostly copy and paste from [its official documentation](https://offirgolan.github.io/ember-cp-validations/docs/modules/Basic.html#objects), is still working in recent Ember versions. I shortly thought about following a more modern pattern [documented by @lifeart in this gist](https://gist.github.com/lifeart/941c3988e152624b0f2eff385d2553d0). But being out of sync with official documentation in this addon may even be more confusing.